### PR TITLE
Add signature input boxes

### DIFF
--- a/agreement-form.html
+++ b/agreement-form.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hazelnut Grower Agreement - Willamette Hazelnut Inc.</title>
+<link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+<style>
+  body {
+    font-family: 'Libre Baskerville', serif;
+    background: #f7f7f7;
+    margin: 0;
+    padding: 20px;
+    color: #333;
+  }
+  header.top-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 10px;
+  }
+  header.top-header .company {
+    font-size: 1.6em;
+    font-weight: bold;
+    color: #4b2e2e; /* brown */
+  }
+  header.top-header .info {
+    text-align: right;
+    color: #264d19; /* dark green */
+    line-height: 1.3;
+    font-size: 0.9em;
+  }
+  .title {
+    text-align: center;
+    font-size: 1.8em;
+    color: #4b2e2e;
+    margin-bottom: 20px;
+  }
+  form {
+    max-width: 900px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  }
+  label {
+    display: block;
+    margin-bottom: 4px;
+    font-weight: bold;
+    color: #264d19;
+  }
+  input[type="text"],
+  input[type="email"],
+  input[type="date"],
+  input[type="tel"],
+  textarea {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-family: inherit;
+  }
+  .inline {
+    display: flex;
+    gap: 20px;
+  }
+  .inline > div {
+    flex: 1;
+  }
+  .form-columns {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 10px;
+  }
+  .form-columns .col {
+    flex: 1;
+  }
+  .small {
+    font-size: 0.8em;
+    font-style: italic;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 15px;
+  }
+  th, td {
+    border: 1px solid #ccc;
+    padding: 6px;
+    text-align: left;
+  }
+  th {
+    background: #e1e1e1;
+  }
+  td input {
+    width: 100%;
+    border: none;
+    padding: 4px;
+    box-sizing: border-box;
+  }
+  .radio-group {
+    margin-bottom: 12px;
+  }
+  .signature {
+    margin-top: 40px;
+    display: flex;
+    justify-content: space-between;
+  }
+  .signature div {
+    width: 45%;
+  }
+  .signature input {
+    width: 100%;
+  }
+  h2 {
+    color: #4b2e2e;
+  }
+  .note {
+    font-size: 0.9em;
+    font-style: italic;
+    margin-top: -8px;
+    margin-bottom: 12px;
+  }
+  .legal-text {
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-bottom: 20px;
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    line-height: 1.4;
+    font-size: 0.85em;
+    background: #f9f9f9;
+  }
+  .cash-section {
+    margin-top: 40px;
+    border-top: 1px solid #ccc;
+    padding-top: 20px;
+  }
+  .signature-lines {
+    margin: 30px 0;
+    display: flex;
+    justify-content: space-between;
+  }
+  .signature-lines div {
+    width: 45%;
+    text-align: center;
+  }
+  .signature-input {
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid #333;
+    padding: 6px;
+    font-family: inherit;
+  }
+</style>
+</head>
+<body>
+<header class="top-header">
+  <div class="company">Willamette Hazelnut Inc.</div>
+  <div class="info">
+    14975 NE Tangen Rd<br>
+    Newberg, Oregon, 97132<br>
+    TEL (503) 538 9256<br>
+    FAX (888) 769 8874<br>
+    www.whazelnut.com
+  </div>
+</header>
+<h1 class="title">HAZELNUT GROWER AGREEMENT</h1>
+<form>
+  <div class="form-columns">
+    <div class="col">
+      <label for="growerName">Grower Name</label>
+      <input id="growerName" type="text" name="growerName">
+
+      <label for="contactName">Contact Name <span class="small">(if needed)</span></label>
+      <input id="contactName" type="text" name="contactName">
+
+      <label for="address">Mailing Address</label>
+      <input id="address" type="text" name="address">
+
+      <div class="inline">
+        <div>
+          <label for="city">City</label>
+          <input id="city" type="text" name="city">
+        </div>
+        <div>
+          <label for="state">State</label>
+          <input id="state" type="text" name="state">
+        </div>
+        <div>
+          <label for="zip">Zip</label>
+          <input id="zip" type="text" name="zip">
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <label for="cropYear">Crop Year</label>
+      <input id="cropYear" type="text" name="cropYear">
+
+      <label for="date">Date</label>
+      <input id="date" type="date" name="date">
+
+      <label for="phoneDay">Phone (Day)</label>
+      <input id="phoneDay" type="tel" name="phoneDay">
+
+      <label for="phoneEve">Phone (Eve)</label>
+      <input id="phoneEve" type="tel" name="phoneEve">
+    </div>
+  </div>
+
+  <div class="inline">
+    <div>
+      <label for="email">Email Address</label>
+      <input id="email" type="email" name="email">
+    </div>
+    <div>
+      <label>HGBA Member</label>
+      <div class="radio-group">
+        <label><input type="radio" name="hgba" value="yes"> Yes</label>
+        <label><input type="radio" name="hgba" value="no"> No</label>
+      </div>
+    </div>
+  </div>
+
+  <h2>Orchard Information</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Orchard Name</th>
+        <th>Acreage</th>
+        <th>Variety</th>
+        <th>Planting Year</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td><input type="text" name="orchard1"></td><td><input type="text" name="acreage1"></td><td><input type="text" name="variety1"></td><td><input type="text" name="year1"></td></tr>
+      <tr><td><input type="text" name="orchard2"></td><td><input type="text" name="acreage2"></td><td><input type="text" name="variety2"></td><td><input type="text" name="year2"></td></tr>
+      <tr><td><input type="text" name="orchard3"></td><td><input type="text" name="acreage3"></td><td><input type="text" name="variety3"></td><td><input type="text" name="year3"></td></tr>
+      <tr><td><input type="text" name="orchard4"></td><td><input type="text" name="acreage4"></td><td><input type="text" name="variety4"></td><td><input type="text" name="year4"></td></tr>
+      <tr><td><input type="text" name="orchard5"></td><td><input type="text" name="acreage5"></td><td><input type="text" name="variety5"></td><td><input type="text" name="year5"></td></tr>
+    </tbody>
+  </table>
+
+  <div class="radio-group">
+    <label>Do Any of Your Orchards Require an Orchard Payment Split?</label><br>
+    <label><input type="radio" name="paymentSplit" value="yes"> Yes</label>
+    <label><input type="radio" name="paymentSplit" value="no"> No</label>
+  </div>
+
+  <label for="payable">Check Payable to:</label>
+  <input id="payable" type="text" name="checkPayable">
+  <p class="note">Minimum price paid and payment date will be per Willamette Hazelnut Inc. Company&rsquo;s published policy.</p>
+
+  <label for="receivedAt">Hazelnuts Received At:</label>
+  <input id="receivedAt" type="text" name="receivedAt">
+
+  <div class="legal-text">
+    <p>Willamette Hazelnut, Inc. (hereafter referred to as Buyer) agrees to buy from Grower and Grower agrees to sell to Buyer the Hazelnut crop (from the described above properties) for the duration hereof. Payment will be made in accordance to the most recent version of the Hazelnut Growers Bargaining Association and Member-Growers&rsquo; Contract with Buyer. Grower assumes all risks of loss, damage, or deterioration of any Hazelnuts occurring prior to final acceptance thereof by Buyer. Grower warrants that Grower is the sole owner of the above described hazelnut crop free of encumbrances; that Grower has not previously contracted to sell or deliver any of said hazelnuts to any other person, that Grower shall not during the durations of this contract either encumber or contract for delivery to any other person the production above described; and that Grower shall deliver said Hazelnuts to Buyer free of all encumbrances. Grower warrants and represents that chemicals and fertilizer applied to acreage contracted herein, have been registered for use on Hazelnuts, and that Good Agricultural Practices (GAP) will be followed in all phases of production and harvesting of Hazelnuts delivered to Buyer. Buyer will refuse to accept delivery of any Lot known to have been treated with chemicals or fertilizer not registered for use on hazelnuts or otherwise not produced and harvested in accordance with GAP. If Grower elects not to participate in Buyer&rsquo;s Cash Advance Payment Program, it is agreed that in the event Grower is unable to deliver said Hazelnuts to Buyer, on account of destruction by floods, weather conditions, or any unavoidable casualties, or in the event that Buyer shall be unable to process, handle, or ship said Hazelnuts on account of quarantine or other governmental restrictions, railroad or labor strikes, fire or other unavoidable casualties, or inability to get supplies on account of such restrictions, strikes, fires, or unavoidable casualties, then this contract shall be null and void upon written notice by either party to the other party or such inability to perform and the reason therefore.</p>
+  </div>
+
+  <div class="signature-lines">
+    <div>
+      <label for="buyerSig">Buyer: Willamette Hazelnut Inc.</label>
+      <input id="buyerSig" type="text" name="buyerSignature" class="signature-input">
+      <div class="small">Type full name</div>
+    </div>
+    <div>
+      <label for="growerSig">Grower:</label>
+      <input id="growerSig" type="text" name="growerSignature" class="signature-input">
+      <div class="small">Type full name</div>
+    </div>
+  </div>
+
+  <div class="cash-section">
+    <h2>Cash Advance Program</h2>
+    <div class="legal-text">
+      <p>Willamette Hazelnut, Inc. (Buyer) conducts a voluntary Cash Advance Program for its grower suppliers. If Grower commits to deliver bearing acres (defined as fourth leaf trees or older), Buyer will advance $300 per acre to Grower upon the execution of this Agreement. Grower understands and agrees that upon delivery of the hazelnut crop to Buyer, the total amount advanced by Buyer to Grower will be deducted from the first payment to Grower. If Grower fails to deliver their hazelnut crop to Buyer on or before October 31st, such non-delivery shall constitute a breach of contract. Buyer will make reasonable efforts to resolve the matter informally before pursuing legal action. In the event legal proceedings are required to enforce this agreement or remedy a breach, the prevailing party shall be entitled to recover reasonable attorney&rsquo;s fees and associated costs.</p>
+    </div>
+    <div class="radio-group">
+      <label>Will You Participate in the Cash Advance Program?</label><br>
+      <label><input type="radio" name="cashAdvance" value="yes"> Yes</label>
+      <label><input type="radio" name="cashAdvance" value="no"> No</label>
+    </div>
+    <div class="signature-lines">
+      <div>
+        <label for="cashBuyerSig">Buyer: Willamette Hazelnut Inc.</label>
+        <input id="cashBuyerSig" type="text" name="cashBuyerSignature" class="signature-input">
+        <div class="small">Type full name</div>
+      </div>
+      <div>
+        <label for="cashGrowerSig">Grower:</label>
+        <input id="cashGrowerSig" type="text" name="cashGrowerSignature" class="signature-input">
+        <div class="small">Type full name</div>
+      </div>
+    </div>
+  </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- use smaller text for `.legal-text`
- replace buyer/grower lines with signature inputs
- add Cash Advance Program section with legal text and signature inputs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877e98880f88331a61c46cbcc05ee33