### PR TITLE
Fix signature pad script and optional tables

### DIFF
--- a/agreement-form.html
+++ b/agreement-form.html
@@ -774,7 +774,6 @@ params.orchardSplitsHTML = buildOrchardSplitsHTML();
       });
     }, 200);
   });
-  });
   
 // para que se generen las tablas en emailjs //
 function buildAdditionalOrchardsHTML() {
@@ -796,8 +795,7 @@ function buildAdditionalOrchardsHTML() {
     }
   }
 
-  return rows
-    ? `<table style="width: 55.8282%; border-collapse: collapse; font-family: Arial, sans-serif; border-width: 1px; margin-left: auto; margin-right: auto;" border="1" cellpadding="8">
+  const header = `<table style="width: 55.8282%; border-collapse: collapse; font-family: Arial, sans-serif; border-width: 1px; margin-left: auto; margin-right: auto;" border="1" cellpadding="8">
         <thead>
           <tr style="height: 35px;">
             <th style="background: #714008; color: #fff;" colspan="4">
@@ -810,10 +808,11 @@ function buildAdditionalOrchardsHTML() {
             <th><span style="font-family: 'times new roman', times, serif;">Variety</span></th>
             <th><span style="font-family: 'times new roman', times, serif;">Planting Year</span></th>
           </tr>
-        </thead>
-        <tbody>${rows}</tbody>
-      </table><br>`
-    : '';
+        </thead>`;
+
+  return rows
+    ? `${header}<tbody>${rows}</tbody></table><br>`
+    : `${header}</table><br>`;
 }
 
 function buildOrchardSplitsHTML() {
@@ -835,8 +834,7 @@ function buildOrchardSplitsHTML() {
     }
   }
 
-  return rows
-    ? `<table style="width: 55.8282%; border-collapse: collapse; font-family: Arial, sans-serif; border-width: 1px; margin-left: auto; margin-right: auto;" border="1" cellpadding="8">
+  const header = `<table style="width: 55.8282%; border-collapse: collapse; font-family: Arial, sans-serif; border-width: 1px; margin-left: auto; margin-right: auto;" border="1" cellpadding="8">
         <thead>
           <tr style="height: 35px;">
             <th style="background: #714008; color: #fff;" colspan="4">
@@ -849,10 +847,11 @@ function buildOrchardSplitsHTML() {
             <th><span style="font-family: 'times new roman', times, serif;">%</span></th>
             <th><span style="font-family: 'times new roman', times, serif;">Address</span></th>
           </tr>
-        </thead>
-        <tbody>${rows}</tbody>
-      </table><br>`
-    : '';
+        </thead>`;
+
+  return rows
+    ? `${header}<tbody>${rows}</tbody></table><br>`
+    : `${header}</table><br>`;
 }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- fix extra closing brace in email submission script so signature pads initialize
- show headers for additional orchards and split information even when no data is filled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889329d0b108331a72c3625fd4a8f07